### PR TITLE
Fix error with mulitple traefik rules.

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,9 +22,6 @@ docker.listContainers()
             var host = rule.slice(6,-2)
             cnames.push(host)
           })
-          // && re2.test(cont.Labels[key])) {
-          //var host = cont.Labels[key].match(re2)
-          //cnames.push(host)
         }
       })
     }

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ const nodemon = require('nodemon')
 const docker = new Docker({socketPath: "/var/run/docker.sock"});
 
 const re = /traefik\.http\.routers\.(.*)\.rule/
-const re2 = /H(OST|ost)\(\`(.*)\`\)/
+const re2 = /Host\(\`(\S*\.local)\`\)/gi
 
 const cnames = [];
 
@@ -17,10 +17,15 @@ docker.listContainers()
       var name = cont.Names[0].substring(1)
       var keys = Object.keys(cont.Labels)
       keys.forEach(key =>{
-        if (re.test(key) && re2.test(cont.Labels[key])) {
-          var host = cont.Labels[key].match(re2)[2]
-          cnames.push(host)
-  }
+        if (re.test(key)) {
+          cont.Labels[key].match(re2).forEach(rule =>{
+            var host = rule.slice(6,-2)
+            cnames.push(host)
+          })
+          // && re2.test(cont.Labels[key])) {
+          //var host = cont.Labels[key].match(re2)
+          //cnames.push(host)
+        }
       })
     }
   }


### PR DESCRIPTION
Change the regex so it will only fit to rules of the form Host(something.local). If multiple rules which fit are in one label, both will be added.

Note:
``Host(`a.something.local`) && Host(`b.something.local`)`` does work.
``Host(`a.something.local`, `b.something.local`)`` does not work. It will not find the rule (if there is at least one white space, error otherwise) and not add it.
Both ways are supported by traefik as readable here: https://doc.traefik.io/traefik/routing/routers/

fixes #3 