### PR TITLE
Fix mixed domain names with .local

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,10 @@
-FROM python:3.8.5-slim-buster
+FROM python:3.9.16-alpine3.17
 LABEL maintainer="Ben Hardill hardillb@gmail.com"
 
 RUN \
-  apt-get update && apt-get install -yqq wget gnupg libdbus-1-dev libglib2.0-dev build-essential && \
-  echo "deb https://deb.nodesource.com/node_12.x buster main" > /etc/apt/sources.list.d/nodesource.list && \
-  wget -qO- https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
-  apt-get update && \
-  apt-get install -yqq nodejs && \
+  apk add --update make cmake pkgconfig gcc libc-dev g++ glib-dev linux-headers dbus dbus-dev && \
+  apk add --update 'nodejs<19' 'npm<10' && \
   pip install -U pip && pip install pipenv && \
-  npm i -g npm@^6 && \
   rm -rf /var/lib/apt/lists/*
 
 WORKDIR /usr/src/app

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ const domainRe = /`(?<domain>[^`]*?\.local)`/g
 let cnames = [];
 
 const matchDomainCnames = function (domainString) {
-	return [...domainString.matchAll(domainRe)].map(match => match.groups.domain)
+  return [...domainString.matchAll(domainRe)].map(match => match.groups.domain)
 }
 
 docker.listContainers()
@@ -55,7 +55,7 @@ docker.listContainers()
       if(!['start', 'stop'].includes(eventJSON.status)){
         return;
       }
-      
+
       var keys = Object.keys(eventJSON.Actor.Attributes)
       keys.forEach(key => {
         if (!re.test(key)) {

--- a/regex-test.js
+++ b/regex-test.js
@@ -4,26 +4,25 @@ const testValues = [
 	"Host(`foo.example.local`) || Host(`bar.example.local`)",
 	"HOST(`foo.example.local`) || ( Host(`baz.example.local`) && Path(`/baz`) )",
 	"Host(`bill.example.local`) || ( Path(`/ben`) && Host(`ben.example.local`) )",
-	"Host( `foo.local`, `bar.local`)"
+	"Host( `foo.local`, `bar.local`)",
+	"Host(`example.com`)",
+	"Host(`foo.example.com`) || Host(`bar.example.local`)",
+	"HOST(`foo.example.local`) || ( Host(`baz.example.com`) && Path(`/baz`) )",
+	"Host(`bill.example.com`) || ( Path(`/ben`) && Host(`ben.example.local`) )",
+	"Host( `foo.com`, `bar.local`)"
 ]
 
-const re = /Host\(\s*`(.*?\.local)`\s*,*\s*\)/gi
-const re2 = /`(.*?\.local)`/g
+const checkRe = /Host\(\s*`(.*?\.local)`\s*,*\s*\)/gi
+const domainRe = /`(?<domain>[^`]*?\.local)`/g
+
+const matchDomainCnames = function (domainString) {
+	return [...domainString.matchAll(domainRe)].map(match => match.groups.domain)
+}
 
 testValues.forEach( l => {
-	if (re.test(l)) {
-		re.lastIndex = 0
-		const matches = [...l.matchAll(re)]
-		for (const match of matches) {
-			if (match[1].includes(',')){
-				const parts = match[0].matchAll(re2)
-				for (const part of parts){
-					console.log(part[1])
-				}
-			} else {
-				console.log(match[1])
-			}
-		}
+	if (checkRe.test(l)) {
+		checkRe.lastIndex = 0
+		console.log(matchDomainCnames(l))
 	} else {
 		console.log("no match - " + l )
 	}


### PR DESCRIPTION
When having `.local` domains mixed with `.com` etc. domains used to cause issues.
You'd get results like
`example.com`` || Host(``example.local`
causing issues as that is not a correct domain.

i've updated the regex and tests to not allow these backticks ` in hosts which is not allowed anyways and this fixes the issues.

Also i've upgraded the docker base to an alpine base of the latest python (3.9.16) and latest nodejs (18) base.
Alpine has the advantage of being much more lightweight (17.92 MB vs 42.59 MB)