### PR TITLE
Include alpine sdk as build essentials

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,9 @@ FROM python:3.9.16-alpine3.17
 LABEL maintainer="Ben Hardill hardillb@gmail.com"
 
 RUN \
-  apk add --update make cmake pkgconfig gcc libc-dev g++ glib-dev linux-headers dbus dbus-dev && \
+  apk add --update alpine-sdk make cmake pkgconfig gcc libc-dev g++ glib-dev linux-headers dbus dbus-dev && \
   apk add --update 'nodejs<19' 'npm<10' && \
-  pip install -U pip && pip install pipenv && \
-  rm -rf /var/lib/apt/lists/*
+  pip install -U pip && pip install pipenv
 
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
It's odd that the build fails, it compiles fine on my server running ubuntu 22.04 x64
I'm guessing it may be a missing dependency for other archs.

I've added `alpine-sdk` to the list of packages to install, it is the equivalent of `build-essentials` so it may contain some packages yet that it needs.