### PR TITLE
Add apparmor profile

### DIFF
--- a/apparmor/traefik-avahi-helper
+++ b/apparmor/traefik-avahi-helper
@@ -1,0 +1,45 @@
+# Modified version of docker-default profile to allow DBUS access
+# https://github.com/moby/moby/blob/master/profiles/apparmor/template.go
+
+#include <tunables/global>
+
+profile traefik-avahi-helper flags=(attach_disconnected,mediate_deleted) {
+  #include <abstractions/base>
+  #include <abstractions/dbus-strict>
+
+  dbus (send) bus=system peer=(name=org.freedesktop.DBus, label=unconfined),
+  dbus (send) bus=system interface=org.freedesktop.Avahi.* peer=(label=unconfined),
+  dbus (send) bus=system interface=org.freedesktop.DBus.Introspectable peer=(label=unconfined),
+
+  network,
+  capability,
+  file,
+  umount,
+
+  # Host (privileged) processes may send signals to container processes.
+  signal (receive) peer=unconfined,
+
+  # Container processes may send signals amongst themselves.
+  signal (send,receive) peer=traefik-avahi-helper,
+
+  deny @{PROC}/* w,   # deny write for all files directly in /proc (not in a subdir)
+  # deny write to files not in /proc/<number>/** or /proc/sys/**
+  deny @{PROC}/{[^1-9],[^1-9][^0-9],[^1-9s][^0-9y][^0-9s],[^1-9][^0-9][^0-9][^0-9]*}/** w,
+  deny @{PROC}/sys/[^k]** w,  # deny /proc/sys except /proc/sys/k* (effectively /proc/sys/kernel)
+  deny @{PROC}/sys/kernel/{?,??,[^s][^h][^m]**} w,  # deny everything except shm* in /proc/sys/kernel/
+  deny @{PROC}/sysrq-trigger rwklx,
+  deny @{PROC}/kcore rwklx,
+
+  deny mount,
+
+  deny /sys/[^f]*/** wklx,
+  deny /sys/f[^s]*/** wklx,
+  deny /sys/fs/[^c]*/** wklx,
+  deny /sys/fs/c[^g]*/** wklx,
+  deny /sys/fs/cg[^r]*/** wklx,
+  deny /sys/firmware/** rwklx,
+  deny /sys/kernel/security/** rwklx,
+
+  # suppress ptrace denials when using 'docker ps' or using 'ps' inside a container
+  ptrace (trace,read,tracedby,readby) peer=traefik-avahi-helper,
+}


### PR DESCRIPTION
I was curious how the security could be improved so delved deep creating an apparmor profile. First time I've created one but seems to work as expected.

Uses docker-default apparmor as a template to allow DBUS calls.

TODO:

- [ ] Add Readme instructions