### PR TITLE
Execute publisher count in the logging function

### DIFF
--- a/cname.py
+++ b/cname.py
@@ -85,7 +85,7 @@ def main():
             if publisher.count() == len(cnames):
                 log.info("All CNAMEs published")
             else:
-                log.warning("%d of %d published", publisher.count, len(cnames))
+                log.warning("%d of %d published", publisher.count(), len(cnames))
 
         sleep(1)
 


### PR DESCRIPTION
Currently when not all CNAMEs have been published we log a different message.
In the check we correctly execute the count function to get the count.
While logging the warning we have forgotten to do so, causing the following error.
```
restarting cname.py with /usr/src/app/cnames
starting cname.py
--- Logging error ---
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/logging/__init__.py", line 1083, in emit
    msg = self.format(record)
  File "/usr/local/lib/python3.9/logging/__init__.py", line 927, in format
    return fmt.format(record)
  File "/usr/local/lib/python3.9/logging/__init__.py", line 663, in format
    record.message = record.getMessage()
  File "/usr/local/lib/python3.9/logging/__init__.py", line 367, in getMessage
    msg = msg % self.args
TypeError: %d format: a number is required, not method
Call stack:
  File "/usr/src/app/cname.py", line 93, in <module>
    main()
  File "/usr/src/app/cname.py", line 88, in main
    log.warning("%d of %d published", publisher.count, len(cnames))
Message: '%d of %d published'
Arguments: (<bound method AvahiPublisher.count of <mpublisher.mpublisher.AvahiPublisher object at 0x7fb04e774760>>, 16)
```